### PR TITLE
Fix lag with optifine and removal of unused field.

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/overlays/EquipmentOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/overlays/EquipmentOverlay.java
@@ -144,8 +144,6 @@ public class EquipmentOverlay {
 
 	public ItemStack petStack;
 
-	private List<String> tooltipsToDisplay;
-
 	//<editor-fold desc="events">
 
 	@SubscribeEvent
@@ -163,13 +161,6 @@ public class EquipmentOverlay {
 	public void onRenderGuiPost(GuiInventoryBackgroundDrawnEvent event) {
 		if (!(event.getContainer() instanceof GuiInventory)) return;
 		GuiInventory inventory = ((GuiInventory) event.getContainer());
-		renderGuis(inventory);
-	}
-
-	@SubscribeEvent
-	public void onMouseClick(GuiScreenEvent.MouseInputEvent event) {
-		if (!(event.gui instanceof GuiInventory)) return;
-		GuiInventory inventory = ((GuiInventory) event.gui);
 		renderGuis(inventory);
 	}
 


### PR DESCRIPTION
Removed onMouseClick as it was triggered more than once per tick when optifine is installed.
Removed tooltipsToDisplay field (as it was replaced by a local variable).